### PR TITLE
Update dmenubar.lua to return the button it creates

### DIFF
--- a/garrysmod/lua/vgui/dmenubar.lua
+++ b/garrysmod/lua/vgui/dmenubar.lua
@@ -29,8 +29,8 @@ end
 function PANEL:AddOrGetMenu( label )
 
 	if ( self.Menus[ label ] ) then return self.Menus[ label ] end
-	return self:AddMenu( label )
-
+	local menu, btn = self:AddMenu( label )
+	return menu, btn
 end
 
 function PANEL:AddMenu( label )
@@ -67,7 +67,7 @@ function PANEL:AddMenu( label )
 		b:DoClick()
 	end
 
-	return m
+	return m, b
 
 end
 


### PR DESCRIPTION
Before this change DMenuBar only returns the DMenu it creates and not the DButton on the actual menubar that opens/closes it. The change is relatively small with just adding an additional secondary return value for that button. 

Shouldn't Break any old code since the menu is still returned first.